### PR TITLE
Add a CI script and prevent error on install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,21 @@
+name: Continuous Integration
+on:
+  - push
+
+jobs:
+  Continuous-Integration:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check Out Code
+        uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+      - name: Install Dependencies
+        run: pnpm install

--- a/modules/mongodb/index.ts
+++ b/modules/mongodb/index.ts
@@ -1,4 +1,4 @@
-import { mongoClient } from '../../utils/mongoClient'
+import { buildMongoClient } from '../../utils/mongoClient'
 // import  redis  from '../../utils/redisClient'
 // import { createClient } from 'redis'
 
@@ -18,6 +18,8 @@ import { userRepository } from '../../server/redisSchemas/user'
 export default async (inlineOptions: any, nuxt: any) => {
   nuxt.hook('listen', async (nuxt: any) => {
     try {
+      const mongoClient = buildMongoClient();
+
       // Connect to database
       await mongoClient.connect()
       console.log(`Database connection succesfull`)

--- a/utils/mongoClient.ts
+++ b/utils/mongoClient.ts
@@ -1,3 +1,6 @@
-import { MongoClient, ObjectId } from 'mongodb'
-const mongoClient = new MongoClient(process.env.NUXT_DB_URL as string)
-export { mongoClient, ObjectId }
+import { MongoClient } from 'mongodb'
+
+export const buildMongoClient = () => {
+  const mongoClient = new MongoClient(process.env.NUXT_DB_URL as string)
+  return mongoClient;
+}


### PR DESCRIPTION
## The Continuous Integration (CI) Script

`.github/workflows/ci.yaml` is a configuration for a [GitHub actions](https://docs.github.com/en/actions) workflow. Once this pull request is merged, any `push` to any branch will trigger the job defined in the workflow. The job actually runs twice, once for ubuntu and once for macos. Under `steps` you can see that it

- checks out the PR branch
- installs node
- installs pnpm
- and installs dependencies

With this script I was able to reproduce the installation issue I was having on both linux and macos. 

## Installation Crash Fix

It looks like nuxt has a [custom module system](https://nuxtjs.org/docs/directory-structure/modules/#write-your-own-module) that is setup as part of the installation of nuxt. This means that `modules/mongodb/index.ts` is run on `pnpm install`, and it tries to make a mongodb client immediately. If you setup this project on a machine that doesn't have mongodb or the right environment variables then the installation will fail.

I deferred the creation of the client to the runtime.